### PR TITLE
WIP: Поддержка генератора документации

### DIFF
--- a/src/OneScript/Application/ApplicationInstance.cs
+++ b/src/OneScript/Application/ApplicationInstance.cs
@@ -191,6 +191,13 @@ namespace OneScript.WebHost.Application
             {
                 options.PreSerializeFilters.Add((swaggerDoc, httpReq) => swaggerDoc.Host = httpReq.Host.Value);
             });
+            
+            //TODO: Get url and name from config
+
+            _startupBuilder.UseSwaggerUI(options =>
+            {
+                options.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
+            });
         }
 
         // TODO:

--- a/src/OneScript/Application/ApplicationInstance.cs
+++ b/src/OneScript/Application/ApplicationInstance.cs
@@ -184,6 +184,15 @@ namespace OneScript.WebHost.Application
             _startupBuilder.UseResponseCompression();
         }
 
+        [ContextMethod("ИспользоватьДокументацию")]
+        public void UseSwagger()
+        {
+            _startupBuilder.UseSwagger(options =>
+            {
+                options.PreSerializeFilters.Add((swaggerDoc, httpReq) => swaggerDoc.Host = httpReq.Host.Value);
+            });
+        }
+
         // TODO:
         // Включить управление консолью, когда будет готова архитектура ролей в целом.
         //[ContextMethod("ИспользоватьКонсольЗаданий")]

--- a/src/OneScript/Infrastructure/SwaggerServicePlugin.cs
+++ b/src/OneScript/Infrastructure/SwaggerServicePlugin.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace OneScript.WebHost.Infrastructure
+{
+    public static class SwaggerServicePlugin
+    {
+        public static void AddOneScriptSwagger(this IServiceCollection services, IConfiguration conf)
+        {
+            services.AddSwaggerGen(options =>
+            {
+                var info = LoadFromConfig(conf);
+                options.SwaggerDoc(info.Version, info);
+            });
+        }
+
+        private static Info LoadFromConfig(IConfiguration config)
+        {
+
+            var infoSection = config?.GetSection("Info");
+
+            Info info = new Info
+            {
+                Version = GetSectionValue(infoSection, "version", "v1"),
+                Title = GetSectionValue(infoSection, "name", "OneScipt API"),
+                Description = GetSectionValue(infoSection, "description"),
+                TermsOfService = GetSectionValue(infoSection, "terms")
+            };
+
+            var licSection = infoSection?.GetSection("License");
+
+            if (licSection != null)
+            {
+                License lic = new License
+                {
+                    Name = GetSectionValue(licSection, "name"),
+                    Url = GetSectionValue(licSection, "url")
+                };
+                info.License = lic;
+            }
+
+            var contactSection = infoSection?.GetSection("Contact");
+
+            if (contactSection != null)
+            {
+                Contact contact = new Contact
+                {
+                    Name = GetSectionValue(contactSection, "name"),
+                    Email = GetSectionValue(contactSection, "email"),
+                    Url = GetSectionValue(contactSection, "url")
+                };
+                info.Contact = contact;
+            }
+
+            return info;
+        }
+
+        private static string GetSectionValue(IConfigurationSection section, string name, string defaultValue = null)
+        {
+            return section?.GetValue<string>(name) ?? defaultValue;
+        }
+    }
+}

--- a/src/OneScript/OneScriptWeb.csproj
+++ b/src/OneScript/OneScriptWeb.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="OneScript" Version="1.0.21" />
     <PackageReference Include="OneScript.StandardLibrary" Version="1.0.21" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\" />

--- a/src/OneScript/Startup.cs
+++ b/src/OneScript/Startup.cs
@@ -73,6 +73,7 @@ namespace OneScript.WebHost
                 .ConfigureApplicationPartManager(pm=>pm.FeatureProviders.Add(new ScriptedViewComponentFeatureProvider()));
 
             services.AddOneScript();
+            services.AddOneScriptSwagger(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
#47 

Пока я собрался сделать ПР.
@EvilBeaver уже добавил поддержку роутинга по атрибутам и корректное заполнение селекторов, что сильно облегчило внедрение.

Генератор работает на основе проекта Swashbuckle
https://github.com/domaindrivendev/Swashbuckle.AspNetCore

Сейчас работает UI и генератор JSON для сваггера.

Модуль включается через метод "ИспользоватьДокументацию" по аналогии с "ИспользоватьМаршруты"

UI доступен по адресу **host:port/swagger**
JSON для UI находится по адресу **host:port/swagger/{version}/swagger.json**
Метаданные, включая версию вынес в конфиг файл (в нашем случае appsettings.json), в секцию "Info", структуру глянуть пока тут
https://github.com/ArchLord42RU/OneScript.Web/blob/e706537104aaeb69e049e7e39fe4e3249d3ae8e3/src/OneScript/Infrastructure/SwaggerServicePlugin.cs
Видны только методы помеченные аннотацией Route\Маршрут(xxx)

Замеченные проблемы:

- Нет описания возвращаемого значения, точней оно всегда ActionResult

- Все методы имеют OperationId "ResultAction" (автоматом присваивается имя метода), не очень страшно, но UI тупит из-за этого, если сделать маппинг на OS методы, то хз как там будет с кириллицей.

- Для UI сейчас захардкожен добавленный эндпоинт, надо бы его из конфига грузить.
https://github.com/EvilBeaver/OneScript.Web/compare/develop...ArchLord42RU:feature/Swagger?expand=1#diff-cf462c11ed5d57c1216462ff171014f7R199

- Нет поддержки версионированного описания API (а надо ли?)




