### PR TITLE
Удалил лишнюю зависимость

### DIFF
--- a/src/OneScript/OneScriptWeb.csproj
+++ b/src/OneScript/OneScriptWeb.csproj
@@ -62,7 +62,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Mono.CSharp" Condition="'$(TargetFramework)' == 'net461'" />
-  </ItemGroup>
 </Project>

--- a/src/OneScript/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/OneScript/Properties/PublishProfiles/FolderProfile.pubxml
@@ -16,6 +16,5 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <publishUrl>D:\osweb</publishUrl>
     <DeleteExistingFiles>True</DeleteExistingFiles>
     <TargetFramework>net461</TargetFramework>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Не обнаружил причин держать Mono.CSharp в зависимостях.