### PR TITLE
Параметры командной строки для запуска из произвольного каталога и в качестве службы

### DIFF
--- a/src/OneScript/Program.cs
+++ b/src/OneScript/Program.cs
@@ -20,29 +20,32 @@ namespace OneScript.WebHost
             if (location != null)
                 config.AddJsonFile(Path.Combine(location, "appsettings.json"), optional: true);
 
-            if (args != null)
-            {
-                config.AddCommandLine(args);
-            }
+            var contentRoot = GetContentRoot(args);
 
-            var configInstance = config.Build();
-
-            string appPath = configInstance.GetValue<string>("AppPath", "");
-
-            if (appPath == "")
-                appPath = Directory.GetCurrentDirectory();
-
-            config.SetBasePath(appPath);
+            config.SetBasePath(contentRoot);
             config.AddJsonFile("appsettings.json", optional: true);
             config.AddEnvironmentVariables("OSWEB_");
             config.AddEnvironmentVariables("ASPNETCORE_");
 
             if (args != null)
             {
-                config.AddCommandLine(args);
+                var argMappings = new Dictionary<string, string>()
+                {
+                    { "--ContentRoot", "Hosting:ContentRoot" },
+                    { "--RunAsService", "Hosting:RunAsService" },
+                    { "--Urls", "Hosting:Urls" }
+                };
+                config.AddCommandLine(args, argMappings);
+                argMappings = new Dictionary<string, string>()
+                {
+                    { "--ContentRoot", "ContentRoot" },
+                    { "--RunAsService", "RunAsService" },
+                    { "--Urls", "Urls" }
+                };
+                config.AddCommandLine(args, argMappings);
             }
 
-            configInstance = config.Build();
+            var configInstance = config.Build();
             var builder = new WebHostBuilder();
             var options = ConfigureHostingMode(builder, configInstance);
 
@@ -75,11 +78,6 @@ namespace OneScript.WebHost
             var options = new HostingOptions();
             config.GetSection("Hosting").Bind(options);
 
-            string appPath = config.GetValue<string>("AppPath", "");
-
-            if (appPath != "")
-                options.ContentRoot = appPath;
-
             if (options.ContentRoot == null)
             {
                 options.ContentRoot = options.RunAsService
@@ -103,6 +101,26 @@ namespace OneScript.WebHost
             public bool RunAsService { get; set; }
             public string ContentRoot { get; set; }
             public string WebRoot { get; set; }
+
+        }
+
+        private static string GetContentRoot(string[] args)
+        {
+            var config = new ConfigurationBuilder();
+
+            if (args != null)
+            {
+                config.AddCommandLine(args);
+            }
+
+            var configInstance = config.Build();
+
+            string contentRoot = configInstance.GetValue<string>("ContentRoot", "");
+
+            if (contentRoot == "")
+                contentRoot = Directory.GetCurrentDirectory();
+
+            return contentRoot;
 
         }
     }

--- a/src/OneScript/Program.cs
+++ b/src/OneScript/Program.cs
@@ -27,12 +27,12 @@ namespace OneScript.WebHost
 
             var configInstance = config.Build();
 
-            string applicationPath = configInstance.GetValue<string>("ApplicationPath", "");
+            string appPath = configInstance.GetValue<string>("AppPath", "");
 
-            if (applicationPath == "")
-                applicationPath = Directory.GetCurrentDirectory();
+            if (appPath == "")
+                appPath = Directory.GetCurrentDirectory();
 
-            config.SetBasePath(applicationPath);
+            config.SetBasePath(appPath);
             config.AddJsonFile("appsettings.json", optional: true);
             config.AddEnvironmentVariables("OSWEB_");
             config.AddEnvironmentVariables("ASPNETCORE_");
@@ -75,10 +75,10 @@ namespace OneScript.WebHost
             var options = new HostingOptions();
             config.GetSection("Hosting").Bind(options);
 
-            string applicationPath = config.GetValue<string>("ApplicationPath", "");
+            string appPath = config.GetValue<string>("AppPath", "");
 
-            if (applicationPath != "")
-                options.ContentRoot = applicationPath;
+            if (appPath != "")
+                options.ContentRoot = appPath;
 
             if (options.ContentRoot == null)
             {

--- a/src/OneScript/Program.cs
+++ b/src/OneScript/Program.cs
@@ -20,7 +20,19 @@ namespace OneScript.WebHost
             if (location != null)
                 config.AddJsonFile(Path.Combine(location, "appsettings.json"), optional: true);
 
-            config.SetBasePath(Directory.GetCurrentDirectory());
+            if (args != null)
+            {
+                config.AddCommandLine(args);
+            }
+
+            var configInstance = config.Build();
+
+            string BasePath = configInstance.GetValue<string>("BasePath", "");
+
+            if (BasePath == "")
+                BasePath = Directory.GetCurrentDirectory();
+
+            config.SetBasePath(BasePath);
             config.AddJsonFile("appsettings.json", optional: true);
             config.AddEnvironmentVariables("OSWEB_");
             config.AddEnvironmentVariables("ASPNETCORE_");
@@ -30,7 +42,7 @@ namespace OneScript.WebHost
                 config.AddCommandLine(args);
             }
 
-            var configInstance = config.Build();
+            configInstance = config.Build();
             var builder = new WebHostBuilder();
             var options = ConfigureHostingMode(builder, configInstance);
 
@@ -62,6 +74,11 @@ namespace OneScript.WebHost
         {
             var options = new HostingOptions();
             config.GetSection("Hosting").Bind(options);
+
+            string BasePath = config.GetValue<string>("BasePath", "");
+
+            if (BasePath != "")
+                options.ContentRoot = BasePath;
 
             if (options.ContentRoot == null)
             {

--- a/src/OneScript/Program.cs
+++ b/src/OneScript/Program.cs
@@ -27,12 +27,12 @@ namespace OneScript.WebHost
 
             var configInstance = config.Build();
 
-            string BasePath = configInstance.GetValue<string>("BasePath", "");
+            string applicationPath = configInstance.GetValue<string>("ApplicationPath", "");
 
-            if (BasePath == "")
-                BasePath = Directory.GetCurrentDirectory();
+            if (applicationPath == "")
+                applicationPath = Directory.GetCurrentDirectory();
 
-            config.SetBasePath(BasePath);
+            config.SetBasePath(applicationPath);
             config.AddJsonFile("appsettings.json", optional: true);
             config.AddEnvironmentVariables("OSWEB_");
             config.AddEnvironmentVariables("ASPNETCORE_");
@@ -75,10 +75,10 @@ namespace OneScript.WebHost
             var options = new HostingOptions();
             config.GetSection("Hosting").Bind(options);
 
-            string BasePath = config.GetValue<string>("BasePath", "");
+            string applicationPath = config.GetValue<string>("ApplicationPath", "");
 
-            if (BasePath != "")
-                options.ContentRoot = BasePath;
+            if (applicationPath != "")
+                options.ContentRoot = applicationPath;
 
             if (options.ContentRoot == null)
             {


### PR DESCRIPTION
Возможность указания в аргументах командной строки рабочего каталога --ContentRoot;
Возможность указания параметра командной строки --RunAsService, для запуска приложения в качестве сервиса;
Возможность указания параметра командной строки --urls, для указания адреса и порта приложения Oscript.Web.